### PR TITLE
correct silvio gesell link

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ title: Freicoin - peer-to-peer demurrage currency
 	<p>
 	Unlike Bitcoin, Freicoin has a <a href="http://en.wikipedia.org/wiki/Demurrage_%28currency%29">demurrage</a>) fee that ensures its circulation and bearers of the currency pay this fee automatically. 
 	
-	This demurrage fee was proposed by <a href="http://en.wikipedia.org/wiki/Demurrage_%28currency%29">Silvio Gesell</a> and has been tested <a href="http://en.wikipedia.org/wiki/Worgl_Experiment#The_W.C3.B6rgl_Experiment">several times</a> with <a href="http://en.wikipedia.org/wiki/Chiemgauer">positive results</a>.
+	This demurrage fee was proposed by <a href="http://en.wikipedia.org/wiki/Silvio_Gesell">Silvio Gesell</a> and has been tested <a href="http://en.wikipedia.org/wiki/Worgl_Experiment#The_W.C3.B6rgl_Experiment">several times</a> with <a href="http://en.wikipedia.org/wiki/Chiemgauer">positive results</a>.
 	 
 	</p>
   </div>


### PR DESCRIPTION
correct silvio gesell link: was pointing to demurrage
